### PR TITLE
Update documentation: Fiber Scheduling typo + Design Principles cleanup

### DIFF
--- a/docs/main-concepts/fiber-scheduling.md
+++ b/docs/main-concepts/fiber-scheduling.md
@@ -44,7 +44,7 @@ pong = Fiber.new { loop { puts "pong"; ping.transfer } }
 ping.transfer
 ```
 
-`Fiber#transform` also allows using the main fiber as a general purpose
+`Fiber#transfer` also allows using the main fiber as a general purpose
 resumable execution context. For that reason, Polyphony uses `Fiber#transfer`
 exclusively for scheduling fibers. Normally, however, applications based on
 Polyphony will not use this API directly.


### PR DESCRIPTION
### Description 📖 

A small typo fix in the _Fiber Scheduling_ page 😃 

Also, some improvements to the _Design Principles_ page, which had some leftover text. Took some liberties to fill in the blanks. I understand that this might be a bit more personal and you might want to edit it differently.

I really like the concept of this library, the mental model is super easy to grasp, the usability is great, and the documentation describes the concepts and the design wonderfully. Congrats!