### PR TITLE
Fix memory leak in ResourcePool

### DIFF
--- a/lib/polyphony/core/resource_pool.rb
+++ b/lib/polyphony/core/resource_pool.rb
@@ -36,7 +36,7 @@ module Polyphony
           @acquired_resources[fiber] = resource
           yield resource
         ensure
-          @acquired_resources[fiber] = nil
+          @acquired_resources.delete fiber
           Thread.current.agent.unref
           release(resource) if resource
         end


### PR DESCRIPTION
Fixes a bug that caused `Fiber` objects to be retained in `ResourcePool` `@acquired_resources` keys resulting in a memory leak.