### PR TITLE
Mysql2 and Sequel adapters

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -72,6 +72,7 @@ GEM
       minitest (>= 5.0)
       ruby-progressbar
     multi_xml (0.6.0)
+    mysql2 (0.5.3)
     parallel (1.19.1)
     parser (2.7.0.2)
       ast (~> 2.4.0)
@@ -109,6 +110,7 @@ GEM
     sass-listen (4.0.0)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
+    sequel (5.34.0)
     simplecov (0.17.1)
       docile (~> 1.1)
       json (>= 1.8, < 3)
@@ -130,11 +132,13 @@ DEPENDENCIES
   localhost (= 1.1.4)
   minitest (= 5.13.0)
   minitest-reporters (= 1.4.2)
+  mysql2 (= 0.5.3)
   pg (= 1.1.4)
   polyphony!
   rake-compiler (= 1.0.5)
   redis (= 4.1.0)
   rubocop (= 0.85.1)
+  sequel (= 5.34.0)
   simplecov (= 0.17.1)
 
 BUNDLED WITH

--- a/examples/adapters/sequel_mysql.rb
+++ b/examples/adapters/sequel_mysql.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'bundler/setup'
+require 'polyphony/adapters/sequel'
+require 'polyphony/adapters/mysql2'
+
+time_printer = spin do
+  last = Time.now
+  throttled_loop(10) do
+    now = Time.now
+    puts now - last
+    last = now
+  end
+end
+
+db = Sequel.connect('mysql2://localhost/test')
+
+x = 10_000
+t0 = Time.now
+x.times { db.execute('select 1 as test') }
+puts "query rate: #{x / (Time.now - t0)} reqs/s"
+
+time_printer.stop

--- a/examples/adapters/sequel_mysql_pool.rb
+++ b/examples/adapters/sequel_mysql_pool.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'bundler/setup'
+require 'polyphony/adapters/sequel'
+require 'polyphony/adapters/mysql2'
+
+CONCURRENCY = ARGV.first ? ARGV.first.to_i : 1000
+puts "concurrency: #{CONCURRENCY}"
+
+db = Sequel.connect(
+  'mysql2://localhost/test',
+  max_connections: 100,
+  preconnect: true
+)
+
+t0 = Time.now
+count = 0
+
+fibers = Array.new(CONCURRENCY) do
+  spin do
+    loop do
+      db.execute('select sleep(0.001) as test')
+      count += 1
+    end
+  end
+end
+
+sleep 0.1
+fibers.first.terminate # Interrupt mid-query
+
+sleep 2
+puts "query rate: #{count / (Time.now - t0)} reqs/s"
+fibers.each(&:interrupt)

--- a/lib/polyphony/adapters/mysql2.rb
+++ b/lib/polyphony/adapters/mysql2.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require_relative '../../polyphony'
+require 'mysql2/client'
+
+# Mysql2::Client overrides
+Mysql2::Client.prepend(Module.new do
+  def initialize(config)
+    config[:async] = true
+    super
+    @io = ::IO.for_fd(socket)
+  end
+
+  def query(sql, **options)
+    super
+    Thread.current.agent.wait_io(@io, false)
+    async_result
+  end
+end)

--- a/lib/polyphony/adapters/sequel.rb
+++ b/lib/polyphony/adapters/sequel.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require_relative '../../polyphony'
+require 'sequel'
+
+module Polyphony
+  # Sequel ConnectionPool that delegates to Polyphony::ResourcePool.
+  class FiberConnectionPool < Sequel::ConnectionPool
+    def initialize(db, opts = OPTS)
+      super
+      max_size = Integer(opts[:max_connections] || 4)
+      @pool = Polyphony::ResourcePool.new(limit: max_size) { make_new(:default) }
+    end
+
+    def hold(_server = nil)
+      @pool.acquire do |conn|
+        yield conn
+      rescue Polyphony::BaseException
+        # The connection may be in an unrecoverable state if interrupted,
+        # discard the connection from the pool so it isn't reused.
+        @pool.discard!
+        raise
+      end
+    end
+
+    def size
+      @pool.size
+    end
+
+    def max_size
+      @pool.limit
+    end
+
+    def preconnect(_concurrent = false)
+      @pool.preheat!
+    end
+  end
+
+  # Override Sequel::Database to use FiberConnectionPool by default.
+  Sequel::Database.prepend(Module.new do
+    def connection_pool_default_options
+      {pool_class: FiberConnectionPool}
+    end
+  end)
+end

--- a/polyphony.gemspec
+++ b/polyphony.gemspec
@@ -32,6 +32,8 @@ Gem::Specification.new do |s|
   s.add_development_dependency  'redis',                '4.1.0'
   s.add_development_dependency  'hiredis',              '0.6.3'
   s.add_development_dependency  'http_parser.rb',       '~>0.6.0'
+  s.add_development_dependency  'mysql2',               '0.5.3'
+  s.add_development_dependency  'sequel',               '5.34.0'
 
   s.add_development_dependency  'jekyll',               '~>3.8.6'
   s.add_development_dependency  'jekyll-remote-theme',  '~>0.4.1'

--- a/test/test_resource_pool.rb
+++ b/test/test_resource_pool.rb
@@ -27,6 +27,27 @@ class ResourcePoolTest < MiniTest::Test
     assert_equal ['a', 'b', 'a', 'b'], results
   end
 
+  def test_discard
+    resources = [+'a', +'b']
+    pool = Polyphony::ResourcePool.new(limit: 2) { resources.shift }
+
+    results = []
+    4.times {
+      spin {
+        snooze
+        pool.acquire { |resource|
+          results << resource
+          pool.discard! if resource == 'b'
+          snooze
+        }
+      }
+    }
+    7.times { snooze }
+
+    assert_equal ['a', 'b', 'a', 'a'], results
+    assert_equal 1, pool.size
+  end
+
   def test_single_resource_limit
     resources = [+'a', +'b']
     pool = Polyphony::ResourcePool.new(limit: 1) { resources.shift }


### PR DESCRIPTION
Since `mysql2` already has an [async interface](https://github.com/brianmario/mysql2#async) its Polyphony adapter turns out to be rather simple.

The adapter for `sequel` just requires plugging in a new `Sequel::ConnectionPool` implementation that delegates to `Polyphony::ResourcePool` and overriding `connection_pool_default_options` to use it as the default.
I added two tweaks to `ResourcePool` to make the example work without issues:
- 8f8f15690607d25a1817a2516f147d81c3348888 is a workaround for #34
- 2185705572eb59b24c5c52bdce0cb833604e73e2 adds `ResourcePool#discard` in order to support discarding connections that are interrupted mid-query and are in an unrecoverable state.