### PR TITLE
Print forked error message

### DIFF
--- a/lib/polyphony.rb
+++ b/lib/polyphony.rb
@@ -57,7 +57,7 @@ module Polyphony
       rescue SystemExit
         # fall through to ensure
       rescue Exception => e
-        e.full_message
+        warn e.full_message
         exit!
       ensure
         exit_forked_process


### PR DESCRIPTION
Before, there was no error output when a fork raised an error:
```
$ ruby -rpolyphony -e "Polyphony.fork {raise 'error'}"
```

Expected (with this fix):
```
$ ruby -rpolyphony -e "Polyphony.fork {raise 'error'}"
Traceback (most recent call last):
-e:1:in `block in <main>': error (RuntimeError)
```