### PR TITLE
Add additional socket config options

### DIFF
--- a/lib/polyphony/extensions/socket.rb
+++ b/lib/polyphony/extensions/socket.rb
@@ -67,6 +67,10 @@ class ::Socket
     setsockopt(Socket::SOL_SOCKET, Socket::SO_REUSEADDR, 1)
   end
 
+  def reuse_port
+    setsockopt(::Socket::SOL_SOCKET, ::Socket::SO_REUSEPORT, 1)
+  end
+
   class << self
     alias_method :orig_getaddrinfo, :getaddrinfo
     def getaddrinfo(*args)
@@ -119,6 +123,10 @@ class ::TCPSocket
 
   def reuse_addr
     setsockopt(::Socket::SOL_SOCKET, ::Socket::SO_REUSEADDR, 1)
+  end
+
+  def reuse_port
+    setsockopt(::Socket::SOL_SOCKET, ::Socket::SO_REUSEPORT, 1)
   end
 end
 

--- a/lib/polyphony/net.rb
+++ b/lib/polyphony/net.rb
@@ -35,9 +35,10 @@ module Polyphony
         ::Socket.new(:INET, :STREAM).tap do |s|
           s.reuse_addr if opts[:reuse_addr]
           s.dont_linger if opts[:dont_linger]
+          s.reuse_port if opts[:reuse_port]
           addr = ::Socket.sockaddr_in(port, host)
           s.bind(addr)
-          s.listen(0)
+          s.listen(opts[:backlog] || Socket::SOMAXCONN)
         end
       end
 


### PR DESCRIPTION
This adds two helpful options for TCP-server socket configuration:

- `:reuse_port` (`SO_REUSEPORT`)
- `:backlog` (listen backlog, default `SOMAXCONN`)