### PR TITLE
Fix reentrant ResourcePool

### DIFF
--- a/lib/polyphony/core/resource_pool.rb
+++ b/lib/polyphony/core/resource_pool.rb
@@ -22,15 +22,17 @@ module Polyphony
 
     def acquire
       fiber = Fiber.current
-      return @acquired_resources[fiber] if @acquired_resources[fiber]
+      return yield @acquired_resources[fiber] if @acquired_resources[fiber]
 
       add_to_stock if (@stock.empty? || @stock.pending?) && @size < @limit 
       resource = @stock.shift
       @acquired_resources[fiber] = resource
       yield resource
     ensure
-      @acquired_resources.delete(fiber)
-      @stock.push resource if resource
+      if resource
+        @acquired_resources.delete(fiber)
+        @stock.push resource
+      end
     end
         
     def method_missing(sym, *args, &block)

--- a/test/test_resource_pool.rb
+++ b/test/test_resource_pool.rb
@@ -75,12 +75,16 @@ class ResourcePoolTest < MiniTest::Test
     resources = [+'a', +'b']
     pool = Polyphony::ResourcePool.new(limit: 1) { resources.shift }
 
+    results = []
     pool.acquire do |r|
-      assert_equal 'a', r
-      pool.acquire do |r|
-        assert_equal 'a', r
+      results << r
+      2.times do
+        pool.acquire do |r|
+          results << r
+        end
       end
     end
+    assert_equal ['a']*3, results
   end
 
   def test_overloaded_resource_pool


### PR DESCRIPTION
Fixes two related bugs in `ResourcePool#acquire`:

- Re-entrant `#acquire` did not `yield` on its inner invocation so re-entrant blocks were not invoked
- Inner invocation's `ensure` clause would delete the fiber's `acquired_resources` entry so a subsequent inner invocation would block (no longer re-entrant).

Updated the existing test to cover these scenarios.