### PR TITLE
Interjection

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,7 +1,19 @@
+
+- Adapter for Pry, or maybe just an adapter for readline
+- Rename Agent to Backend
+- Review all code
+  - Cleanup C code
+  - Cleanup Ruby code (use Rubocop)
+  - Cleanup and annotate examples (and remove all the examples used for
+    debugging). Focus on examples that serve as "how-to".
+
+
+
+# 0.44
+
 - Debugging
   - Eat your own dogfood: need a good tool to check what's going on when some
     test fails
-  - Needs to work with Pry (can write perhaps an extension for pry)
   - First impl in Ruby using `TracePoint` API
   - Mode of operation:
     - Two parts: tracer and controller
@@ -111,7 +123,7 @@
   - discuss using `snooze` for ensuring responsiveness when executing CPU-bound work
 
 
-## 0.44
+## 0.45
 
 ### Some more API work, more docs
 
@@ -124,13 +136,13 @@
   - proceed from there
 
 
-## 0.45
+## 0.46
 
 ### Sinatra / Sidekiq
 
 - Pull out redis/postgres code, put into new `polyphony-xxx` gems
 
-## 0.46
+## 0.47
 
 ### Testing && Docs
 
@@ -141,10 +153,6 @@
   - `IO#read` (read to EOF)
   - `IO.foreach`
   - `Process.waitpid`
-
-## 0.47
-
-### Real IO#gets and IO#read
 
 ## 0.48 DNS
 

--- a/ext/polyphony/libev_agent.c
+++ b/ext/polyphony/libev_agent.c
@@ -376,7 +376,7 @@ VALUE LibevAgent_read(VALUE self, VALUE io, VALUE str, VALUE length, VALUE to_eo
 
   return str;
 error:
-  return rb_funcall(rb_mKernel, ID_raise, 1, switchpoint_result);
+  return RAISE_EXCEPTION(switchpoint_result);
 }
 
 VALUE LibevAgent_read_loop(VALUE self, VALUE io) {
@@ -456,7 +456,7 @@ VALUE LibevAgent_read_loop(VALUE self, VALUE io) {
 
   return io;
 error:
-  return rb_funcall(rb_mKernel, ID_raise, 1, switchpoint_result);
+  return RAISE_EXCEPTION(switchpoint_result);
 }
 
 VALUE LibevAgent_write(VALUE self, VALUE io, VALUE str) {
@@ -500,7 +500,7 @@ VALUE LibevAgent_write(VALUE self, VALUE io, VALUE str) {
 
   return INT2NUM(len);
 error:
-  return rb_funcall(rb_mKernel, ID_raise, 1, switchpoint_result);
+  return RAISE_EXCEPTION(switchpoint_result);
 }
 
 VALUE LibevAgent_writev(VALUE self, VALUE io, int argc, VALUE *argv) {
@@ -570,7 +570,7 @@ VALUE LibevAgent_writev(VALUE self, VALUE io, int argc, VALUE *argv) {
   return INT2NUM(total_written);
 error:
   free(iov);
-  return rb_funcall(rb_mKernel, ID_raise, 1, switchpoint_result);
+  return RAISE_EXCEPTION(switchpoint_result);
 }
 
 VALUE LibevAgent_write_m(int argc, VALUE *argv, VALUE self) {
@@ -636,7 +636,7 @@ VALUE LibevAgent_accept(VALUE self, VALUE sock) {
   RB_GC_GUARD(switchpoint_result);
   return Qnil;
 error:
-  return rb_funcall(rb_mKernel, ID_raise, 1, switchpoint_result);
+  return RAISE_EXCEPTION(switchpoint_result);
 }
 
 VALUE LibevAgent_accept_loop(VALUE self, VALUE sock) {
@@ -692,7 +692,7 @@ VALUE LibevAgent_accept_loop(VALUE self, VALUE sock) {
   RB_GC_GUARD(switchpoint_result);
   return Qnil;
 error:
-  return rb_funcall(rb_mKernel, ID_raise, 1, switchpoint_result);
+  return RAISE_EXCEPTION(switchpoint_result);
 }
 
 VALUE LibevAgent_connect(VALUE self, VALUE sock, VALUE host, VALUE port) {
@@ -728,7 +728,7 @@ VALUE LibevAgent_connect(VALUE self, VALUE sock, VALUE host, VALUE port) {
   RB_GC_GUARD(switchpoint_result);
   return sock;
 error:
-  return rb_funcall(rb_mKernel, ID_raise, 1, switchpoint_result);
+  return RAISE_EXCEPTION(switchpoint_result);
 }
 
 VALUE libev_wait_fd(LibevAgent_t *agent, int fd, int events, int raise_exception) {

--- a/ext/polyphony/libev_agent.c
+++ b/ext/polyphony/libev_agent.c
@@ -77,15 +77,13 @@ VALUE LibevAgent_post_fork(VALUE self) {
   LibevAgent_t *agent;
   GetLibevAgent(self, agent);
 
-  if (!ev_is_default_loop(agent->ev_loop)) {
-    // post_fork is called only for the main thread of the forked process. If
-    // the forked process was forked from a thread other than the main one,
-    // we remove the old non-default ev_loop and use the default one instead.
-    ev_loop_destroy(agent->ev_loop);
-    agent->ev_loop = EV_DEFAULT;
-  }
-
-  ev_loop_fork(agent->ev_loop);
+  // After fork there may be some watchers still active left over from the
+  // parent, so we destroy the loop, even if it's the default one, then use the
+  // default one, as post_fork is called only from the main thread of the forked
+  // process. That way we don't need to call ev_loop_fork, since the loop is
+  // always a fresh one.
+  ev_loop_destroy(agent->ev_loop);
+  agent->ev_loop = EV_DEFAULT;
 
   return self;
 }
@@ -142,11 +140,11 @@ VALUE LibevAgent_poll(VALUE self, VALUE nowait, VALUE current_fiber, VALUE queue
 
   agent->run_no_wait_count = 0;
   
-  FIBER_TRACE(2, SYM_fiber_ev_loop_enter, current_fiber);
+  COND_TRACE(2, SYM_fiber_ev_loop_enter, current_fiber);
   agent->running = 1;
   ev_run(agent->ev_loop, is_nowait ? EVRUN_NOWAIT : EVRUN_ONCE);
   agent->running = 0;
-  FIBER_TRACE(2, SYM_fiber_ev_loop_leave, current_fiber);
+  COND_TRACE(2, SYM_fiber_ev_loop_leave, current_fiber);
 
   return self;
 }

--- a/ext/polyphony/polyphony.c
+++ b/ext/polyphony/polyphony.c
@@ -7,6 +7,7 @@ ID ID_caller;
 ID ID_clear;
 ID ID_each;
 ID ID_inspect;
+ID ID_invoke;
 ID ID_new;
 ID ID_raise;
 ID ID_ivar_running;
@@ -60,6 +61,7 @@ void Init_Polyphony() {
   ID_clear          = rb_intern("clear");
   ID_each           = rb_intern("each");
   ID_inspect        = rb_intern("inspect");
+  ID_invoke         = rb_intern("invoke");
   ID_ivar_running   = rb_intern("@running");
   ID_ivar_thread    = rb_intern("@thread");
   ID_new            = rb_intern("new");

--- a/ext/polyphony/polyphony.h
+++ b/ext/polyphony/polyphony.h
@@ -15,9 +15,11 @@
 
 #define TEST_EXCEPTION(ret) (RTEST(rb_obj_is_kind_of(ret, rb_eException)))
 
+#define RAISE_EXCEPTION(e) rb_funcall(e, ID_invoke, 0);
 #define TEST_RESUME_EXCEPTION(ret) if (RTEST(rb_obj_is_kind_of(ret, rb_eException))) { \
-  return rb_funcall(rb_mKernel, ID_raise, 1, ret); \
+  return RAISE_EXCEPTION(ret); \
 }
+
 
 extern agent_interface_t agent_interface;
 #define __AGENT__ (agent_interface)
@@ -32,6 +34,7 @@ extern ID ID_clear;
 extern ID ID_each;
 extern ID ID_fiber_trace;
 extern ID ID_inspect;
+extern ID ID_invoke;
 extern ID ID_ivar_agent;
 extern ID ID_ivar_running;
 extern ID ID_ivar_thread;

--- a/ext/polyphony/polyphony.h
+++ b/ext/polyphony/polyphony.h
@@ -8,9 +8,13 @@
 
 // debugging
 #define OBJ_ID(obj) (NUM2LONG(rb_funcall(obj, rb_intern("object_id"), 0)))
-#define INSPECT(str, obj) { printf(str); VALUE s = rb_funcall(obj, rb_intern("inspect"), 0); printf("%s\n", StringValueCStr(s));}
-#define FIBER_TRACE(...) if (__tracing_enabled__) { \
-  rb_funcall(rb_cObject, ID_fiber_trace, __VA_ARGS__); \
+#define INSPECT(str, obj) { printf(str); VALUE s = rb_funcall(obj, rb_intern("inspect"), 0); printf("%s\n", StringValueCStr(s)); }
+#define TRACE_CALLER() { VALUE c = rb_funcall(rb_mKernel, rb_intern("caller"), 0); INSPECT("caller: ", c); }
+
+// tracing
+#define TRACE(...)  rb_funcall(rb_cObject, ID_fiber_trace, __VA_ARGS__)
+#define COND_TRACE(...) if (__tracing_enabled__) { \
+  TRACE(__VA_ARGS__); \
 }
 
 #define TEST_EXCEPTION(ret) (RTEST(rb_obj_is_kind_of(ret, rb_eException)))

--- a/lib/polyphony/core/exceptions.rb
+++ b/lib/polyphony/core/exceptions.rb
@@ -33,4 +33,15 @@ module Polyphony
 
   # Restart is used to restart a fiber
   class Restart < BaseException; end
+
+  # Interjection is used to run arbitrary code on arbitrary fibers at any point
+  class Interjection < BaseException
+    def initialize(proc)
+      @proc = proc
+    end
+
+    def invoke
+      @proc.call
+    end
+  end
 end

--- a/lib/polyphony/extensions/core.rb
+++ b/lib/polyphony/extensions/core.rb
@@ -46,6 +46,10 @@ class ::Exception
 
     backtrace.reject { |l| l[POLYPHONY_DIR] }
   end
+
+  def invoke
+    Kernel.raise(self)
+  end
 end
 
 # Overrides for Process

--- a/lib/polyphony/extensions/core.rb
+++ b/lib/polyphony/extensions/core.rb
@@ -144,8 +144,16 @@ module ::Kernel
   def trap(sig, command = nil, &block)
     return orig_trap(sig, command) if command.is_a? String
       
-    block = command if command.respond_to?(:call) && !block
-    exception = command.is_a?(Class) && command.new
+    block = command if !block && command.respond_to?(:call)
+    if block
+      exception = Polyphony::Interjection.new(block)
+    else
+      exception = command.is_a?(Class) && command.new
+    end
+
+    unless exception
+      raise ArgumentError, "Must supply block or exception or callable object"
+    end
 
     # The signal trap can be invoked at any time, including while the system
     # agent is blocking while polling for events. In order to deal with this
@@ -156,12 +164,7 @@ module ::Kernel
     # If the command argument is an exception class however, it will be raised
     # directly in the context of the main fiber.
     orig_trap(sig) do
-      if exception
-        Thread.current.break_out_of_ev_loop(Thread.main.main_fiber, exception)
-      else
-        fiber = spin { snooze; block.call }
-        Thread.current.break_out_of_ev_loop(fiber, nil)
-      end
+      Thread.current.break_out_of_ev_loop(Thread.main.main_fiber, exception)
     end
   end
 end

--- a/lib/polyphony/extensions/fiber.rb
+++ b/lib/polyphony/extensions/fiber.rb
@@ -67,6 +67,10 @@ module Polyphony
       else RuntimeError.new
       end
     end
+
+    def interject(&block)
+      raise Polyphony::Interjection.new(block)
+    end
   end
 
   # Fiber supervision

--- a/test/test_fiber.rb
+++ b/test/test_fiber.rb
@@ -413,6 +413,22 @@ class FiberTest < MiniTest::Test
     f2&.stop
   end
 
+  def test_interject
+    buf = []
+    f = spin_loop { sleep }
+    snooze
+    f.interject { buf << Fiber.current }
+    snooze
+    assert_equal [f], buf
+    assert_equal :waiting, f.state
+
+    f.interject { buf << :foo; raise Polyphony::MoveOn }
+    snooze
+
+    assert_equal [f, :foo], buf
+    assert_equal :dead, f.state
+  end
+
   def test_state
     counter = 0
     f = spin do

--- a/test/test_signal.rb
+++ b/test/test_signal.rb
@@ -56,35 +56,11 @@ class SignalTrapTest < Minitest::Test
     assert_equal "3 - interrupted\n2 - terminated\n1 - terminated\n", buffer
   end
 
-  def test_signal_exception_possible_race_condition
+  def test_interrupt_signal_scheduling
     i, o = IO.pipe
     pid = Polyphony.fork do
       i.close
-      f1 = nil
-      f2 = spin do
-        # this fiber will try to create a race condition by
-        # - being scheduled before f1 is scheduled with the Interrupt exception
-        # - scheduling f1 without an exception
-        suspend
-        f1.schedule
-      rescue ::Interrupt => e
-        o.puts '2-interrupt'
-        raise e
-      end
-      f1 = spin do
-        # this fiber is the one that will be current when the
-        # signal is trapped
-        sleep 1
-        o << 'boom'
-      rescue ::Interrupt => e
-        o.puts '1-interrupt'
-        raise e
-      end
-      old_trap = trap('INT') do
-        f2.schedule
-        old_trap.()
-      end
-      Fiber.current.await_all_children
+      sleep
     rescue ::Interrupt => e
       o.puts '3-interrupt'
     ensure


### PR DESCRIPTION
This introduces `Fiber#interject`, a way to run arbitrary code on arbitrary fibers. This is in turn used to implement a better behaving `Kernel.trap`, along with a better `Polyphony.fork`.