### PR TITLE
Fix KERNEL_INFO_RE

### DIFF
--- a/ext/polyphony/extconf.rb
+++ b/ext/polyphony/extconf.rb
@@ -5,7 +5,7 @@ require 'mkmf'
 
 dir_config 'polyphony_ext'
 
-KERNEL_INFO_RE = /Linux (\d)\.(\d+)\.(?:\d+)\-(?:\d+\-)?(\w+)/
+KERNEL_INFO_RE = /Linux (\d)\.(\d+)(?:\.)?((?:\d+\.?)*)(?:\-)?([\w\-]+)?/
 def get_config
   config = { linux: !!(RUBY_PLATFORM =~ /linux/) }
   return config if !config[:linux]


### PR DESCRIPTION
Polyphony fails to build if `uname -sr` is not formed a certain way

Current regex requires:
* 3 digits
* word at the end

Other samples I found:
* `Linux 5.10.60.1-microsoft-standard-WSL2` (Windows Subsystem for Linux), includes `-` in word.
* `Linux 5.10.63+` (raspbian), no word present

I propose:
`Linux (\d)\.(\d+)(?:\.)?((?:\d+\.?)*)(?:\-)?([\w\-]+)?`

Which will match on:
`Linux 5.10.63.62.63`, infinite patch numbers
`Linux 5.10.60.1-microsoft-standard-WSL2`, word at the end including `-`

Test: https://regex101.com/r/CLX00x/1