### PR TITLE
Fix KERNEL_INFO_RE

### DIFF
--- a/ext/polyphony/extconf.rb
+++ b/ext/polyphony/extconf.rb
@@ -5,7 +5,7 @@ require 'mkmf'
 
 dir_config 'polyphony_ext'
 
-KERNEL_INFO_RE = /Linux (\d)\.(\d+)\.(?:\d+)\-(?:\d+\-)?(\w+)/
+KERNEL_INFO_RE = /Linux (\d)\.(\d+)(?:\.)?((?:\d+\.?)*)(?:\-)?([\w\-]+)?/
 def get_config
   config = { linux: !!(RUBY_PLATFORM =~ /linux/) }
   return config if !config[:linux]
@@ -14,7 +14,7 @@ def get_config
   m = kernel_info.match(KERNEL_INFO_RE)
   raise "Could not parse Linux kernel information (#{kernel_info.inspect})" if !m
 
-  version, major_revision, distribution = m[1].to_i, m[2].to_i, m[3]
+  version, major_revision, distribution = m[1].to_i, m[2].to_i, m[4]
   config[:pidfd_open] = (version == 5) && (major_revision >= 3)
 
   force_libev = ENV['POLYPHONY_LIBEV'] != nil


### PR DESCRIPTION
Polyphony fails to build if `uname -sr` is not formed a certain way, since `$KERNEL_INFO_RE` does not match on some systems.

Current regex requires:
* 3 digits
* word at the end

Other samples I found:
* `Linux 5.10.60.1-microsoft-standard-WSL2` (Windows Subsystem for Linux), includes `-` in word.
* `Linux 5.10.63+` (raspbian), no word present

I propose:
`Linux (\d)\.(\d+)(?:\.)?((?:\d+\.?)*)(?:\-)?([\w\-]+)?`

Which will match on:
`Linux 5.10.63.62.63`, infinite patch numbers
`Linux 5.10.60.1-microsoft-standard-WSL2`, word at the end including `-`

This should ensure
* Remaining revision/patch-version is always in group 3
* Distribution is always in group 4
* Both groups are optional

Test: https://regex101.com/r/CLX00x/1