### PR TITLE
Rename receive_pending to receive_all_pending in documentation

### DIFF
--- a/docs/api-reference/fiber.md
+++ b/docs/api-reference/fiber.md
@@ -212,7 +212,7 @@ spin { Fiber.current.parent << 'hello from child' }
 message = receive #=> 'hello from child'
 ```
 
-### #receive_pending → [*object]
+### #receive_all_pending → [*object]
 
 Returns all messages currently in the mailbox, emptying the mailbox. This method
 does not block if no the mailbox is already empty. This method may be used to
@@ -225,7 +225,7 @@ worker = spin do
     handle_job(job)
   end
 rescue Polyphony::Terminate => e
-  receive_pending.each { |job| handle_job(job) }
+  receive_all_pending.each { |job| handle_job(job) }
 end
 ```
 

--- a/docs/api-reference/object.md
+++ b/docs/api-reference/object.md
@@ -63,9 +63,9 @@ result #=> 'bar'
 
 Shortcut for `Fiber.current.receive`
 
-### #receive_pending → [*object]
+### #receive_all_pending → [*object]
 
-Shortcut for `Fiber.current.receive_pending`
+Shortcut for `Fiber.current.receive_all_pending`
 
 ### #sleep(duration = nil) → fiber
 

--- a/docs/main-concepts/exception-handling.md
+++ b/docs/main-concepts/exception-handling.md
@@ -229,7 +229,7 @@ def do_work
   end
 rescue Polyphony::Terminate
   # We still need to handle any pending request
-  receive_pending.each { handle_req(req) }
+  receive_all_pending.each { handle_req(req) }
 end
 
 # on the main fiber


### PR DESCRIPTION
`Fiber#receive_pending` was renamed to `Fiber#receive_all_pending` in 7344a6df0441f0bcc102cbb5921fdeb77dc64cbf.