### PR TITLE
Fix integration with `pry`

### DIFF
--- a/examples/core/await.rb
+++ b/examples/core/await.rb
@@ -2,7 +2,7 @@
 
 require 'bundler/setup'
 require 'polyphony'
-require 'polyphony/extensions/debug'
+require 'polyphony/core/debug'
 
 Exception.__disable_sanitized_backtrace__ = true
 

--- a/examples/io/readline.rb
+++ b/examples/io/readline.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require 'bundler/setup'
+require 'polyphony'
+require 'polyphony/adapters/readline'
+
+$counter = 0
+timer = spin do
+  throttled_loop(5) do
+    $counter += 1
+  end
+end
+
+at_exit { timer.stop }
+
+puts 'try typing $counter to see the counter incremented in the background'
+loop do
+  puts eval Readline::readline('> ', true)
+end

--- a/lib/polyphony/adapters/readline.rb
+++ b/lib/polyphony/adapters/readline.rb
@@ -7,11 +7,13 @@ require 'readline'
 # thread pool. That way, the reactor loop can keep running while waiting for
 # readline to return
 module ::Readline
-  alias_method :orig_readline, :readline
+  class << self
+    alias_method :orig_readline, :readline
 
-  Worker = Polyphony::ThreadPool.new(1)
+    Worker = Polyphony::ThreadPool.new(1)
 
-  def readline(*args)
-    Worker.process { orig_readline(*args) }
+    def readline(*args)
+      Worker.process { orig_readline(*args) }
+    end
   end
 end

--- a/lib/polyphony/core/sync.rb
+++ b/lib/polyphony/core/sync.rb
@@ -101,6 +101,8 @@ module Polyphony
     #
     # @return [void]
     def signal
+      return if @queue.empty?
+
       fiber = @queue.shift
       fiber.schedule
     end
@@ -109,6 +111,8 @@ module Polyphony
     #
     # @return [void]
     def broadcast
+      return if @queue.empty?
+
       while (fiber = @queue.shift)
         fiber.schedule
       end

--- a/lib/polyphony/debugger.rb
+++ b/lib/polyphony/debugger.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'polyphony/extensions/debug'
+require 'polyphony/core/debug'
 
 module Polyphony
   TP_EVENTS = [

--- a/lib/polyphony/debugger.rb
+++ b/lib/polyphony/debugger.rb
@@ -188,7 +188,7 @@ module Polyphony
     def start_server_thread
       @thread = Thread.new do
         puts("Listening on #{@socket_path}")
-        FileUtils.rm(@socket_path) if File.exists?(@socket_path)
+        FileUtils.rm(@socket_path) if File.exist?(@socket_path)
         socket = UNIXServer.new(@socket_path)
         loop do
           @client = socket.accept


### PR DESCRIPTION
An attempt at restoring the integration with `pry`:
- Override the `Readline::readline` method as the original implementation was still being called
- Don't block `ConditionVariable#signal` and `#broadcast` due to `Queue#shift` when there are no fibers waiting

Let me know if you have any thoughts.