### PR TITLE
Return empty string when reading length zero

### DIFF
--- a/lib/polyphony/extensions/io.rb
+++ b/lib/polyphony/extensions/io.rb
@@ -143,6 +143,8 @@ class ::IO
 
   alias_method :orig_read, :read
   def read(len = nil, buf = nil, buf_pos = 0)
+    return '' if len == 0
+
     if buf
       return Polyphony.backend_read(self, buf, len, true, buf_pos)
     end

--- a/test/test_io.rb
+++ b/test/test_io.rb
@@ -93,6 +93,13 @@ class IOTest < MiniTest::Test
     assert_equal 'deffoobar', buf
   end
   
+  def test_read_zero
+    i, o = IO.pipe
+
+    o << 'hi'
+    assert_equal '', i.read(0)
+  end
+  
   def test_readpartial
     i, o = IO.pipe
     


### PR DESCRIPTION
Ruby's `read` always returns an empty string on read with length zero, not `nil`. Polyphony should do this as well.

Discovered through `rubyzip` reading/writing zero-length comments, which failed and caused the zip entry to be overwritten.