### PR TITLE
Update tutorial.md to fix broken image tag

### DIFF
--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -94,7 +94,7 @@ The above program does nothing exceptional, it just sleeps for 1 second and
 prints a bunch of messages. But it is enough to demonstrate how concurrency
 works in Polyphony. Here's a flow chart of the transfer of control:
 
-<img src="https://github.com/digital-fabric/polyphony/raw/master/docs/assets/sleeping-fiber.png">
+<img src="https://github.com/digital-fabric/polyphony/raw/master/docs/assets/sleeping-fiber.svg">
 
 Here's the actual sequence of execution (in pseudo-code)
 

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -189,7 +189,7 @@ innocent call to `#spin`.
 
 Here's a flow chart showing the transfer of control between the different fibers:
 
-<img src="https://github.com/digital-fabric/polyphony/raw/master/docs/assets/echo-fibers.png">
+<img src="https://github.com/digital-fabric/polyphony/raw/master/docs/assets/echo-fibers.svg">
 
 Let's consider the advantage of the Polyphony concurrency model:
 


### PR DESCRIPTION
I noticed there was a broken image in the tutorial and it looked like it just needed to be updated to point to the svg instead of the png.