### PR TITLE
Reference Socket::ZERO_LINGER constant

### DIFF
--- a/lib/polyphony/extensions/socket.rb
+++ b/lib/polyphony/extensions/socket.rb
@@ -177,7 +177,7 @@ class ::Socket < ::BasicSocket
   #
   # @return [::Socket] self
   def dont_linger
-    setsockopt(Socket::SOL_SOCKET, Socket::SO_LINGER, ZERO_LINGER)
+    setsockopt(Socket::SOL_SOCKET, Socket::SO_LINGER, Socket::ZERO_LINGER)
     self
   end
 
@@ -287,7 +287,7 @@ class ::TCPSocket < ::IPSocket
   #
   # @return [::Socket] self
   def dont_linger
-    setsockopt(Socket::SOL_SOCKET, Socket::SO_LINGER, ZERO_LINGER)
+    setsockopt(Socket::SOL_SOCKET, Socket::SO_LINGER, Socket::ZERO_LINGER)
     self
   end
 

--- a/test/test_socket.rb
+++ b/test/test_socket.rb
@@ -163,6 +163,17 @@ class TCPSocketTest < MiniTest::Test
     server_fiber&.await
     server&.close
   end
+
+  def test_sockopt
+    client = TCPSocket.open('ipinfo.io', 80)
+
+    client.dont_linger
+    client.no_delay
+    client.reuse_addr
+    client.reuse_port
+  ensure
+    client.close
+  end
 end
 
 class UNIXSocketTest < MiniTest::Test


### PR DESCRIPTION
The `ZERO_LINGER` constant was referenced incorrectly in the base class, leading subclasses like `TCPSocket` to raise `uninitialized constant TCPSocket::ZERO_LINGER`.