### PR TITLE
Use only positional arguments in read and readpartial

### DIFF
--- a/lib/polyphony/extensions/io.rb
+++ b/lib/polyphony/extensions/io.rb
@@ -197,7 +197,7 @@ class ::IO
   alias_method :orig_read, :read
 
   # @!visibility private
-  def read(len = nil, buf = nil, buffer_pos: 0)
+  def read(len = nil, buf = nil, buffer_pos = 0)
     return '' if len == 0
     return Polyphony.backend_read(self, buf, len, true, buffer_pos) if buf
 
@@ -214,7 +214,7 @@ class ::IO
   alias_method :orig_readpartial, :read
 
   # @!visibility private
-  def readpartial(len, str = +'', buffer_pos: 0, raise_on_eof: true)
+  def readpartial(len, str = +'', buffer_pos = 0, raise_on_eof = true)
     result = Polyphony.backend_read(self, str, len, false, buffer_pos)
     raise EOFError if !result && raise_on_eof
 
@@ -255,7 +255,7 @@ class ::IO
       idx = @read_buffer.index(sep)
       return @read_buffer.slice!(0, idx + sep_size) if idx
 
-      result = readpartial(8192, @read_buffer, buffer_pos: -1)
+      result = readpartial(8192, @read_buffer, -1)
       return nil unless result
     end
   rescue EOFError
@@ -280,7 +280,7 @@ class ::IO
         yield line
       end
 
-      result = readpartial(8192, @read_buffer, buffer_pos: -1)
+      result = readpartial(8192, @read_buffer, -1)
       return self if !result
     end
   rescue EOFError

--- a/lib/polyphony/extensions/openssl.rb
+++ b/lib/polyphony/extensions/openssl.rb
@@ -90,7 +90,7 @@ class ::OpenSSL::SSL::SSLSocket
 
   # Reads from the socket. If `maxlen` is given, reads up to `maxlen` bytes from
   # the socket, otherwise reads to `EOF`. If `buf` is given, it is used as the
-  # buffer to read into, otherwise a new string is allocated. If `buf_pos` is
+  # buffer to read into, otherwise a new string is allocated. If `buffer_pos` is
   # given, reads into the given offset (in bytes) in the given buffer. If the
   # given buffer offset is negative, it is calculated from the current end of
   # the buffer (`-1` means the read data will be appended to the end of the
@@ -101,21 +101,21 @@ class ::OpenSSL::SSL::SSLSocket
   #
   # @param maxlen [Integer, nil] maximum bytes to read from socket
   # @param buf [String, nil] buffer to read into
-  # @param buf_pos [Number] buffer position to read into
+  # @param buffer_pos [Number] buffer position to read into
   # @return [String] buffer used for reading
-  def read(maxlen = nil, buf = nil, buffer_pos: 0)
-    return readpartial(maxlen, buf, buffer_pos:) if buf
+  def read(maxlen = nil, buf = nil, buffer_pos = 0)
+    return readpartial(maxlen, buf, buffer_pos) if buf
 
     buf = +''
     return readpartial(maxlen, buf) if maxlen
 
-    readpartial(4096, buf, buffer_pos: -1) while true
+    readpartial(4096, buf, -1) while true
   rescue EOFError
     buf
   end
 
   # Reads up to `maxlen` from the socket. If `buf` is given, it is used as the
-  # buffer to read into, otherwise a new string is allocated. If `buf_pos` is
+  # buffer to read into, otherwise a new string is allocated. If `buffer_pos` is
   # given, reads into the given offset (in bytes) in the given buffer. If the
   # given buffer offset is negative, it is calculated from the current end of
   # the buffer (`-1` means the read data will be appended to the end of the
@@ -127,16 +127,16 @@ class ::OpenSSL::SSL::SSLSocket
   #
   # @param maxlen [Integer, nil] maximum bytes to read from socket
   # @param buf [String, nil] buffer to read into
-  # @param buf_pos [Number] buffer position to read into
+  # @param buffer_pos [Number] buffer position to read into
   # @param raise_on_eof [bool] whether to raise an exception on `EOF`
   # @return [String, nil] buffer used for reading or nil on `EOF`
-  def readpartial(maxlen, buf = +'', buffer_pos: 0, raise_on_eof: true)
-    if buf_pos != 0
+  def readpartial(maxlen, buf = +'', buffer_pos = 0, raise_on_eof = true)
+    if buffer_pos != 0
       if (result = sysread(maxlen, +''))
-        if buf_pos == -1
+        if buffer_pos == -1
           result = buf + result
         else
-          result = buf[0...buf_pos] + result
+          result = buf[0...buffer_pos] + result
         end
       end
     else

--- a/lib/polyphony/extensions/pipe.rb
+++ b/lib/polyphony/extensions/pipe.rb
@@ -41,9 +41,9 @@ class Polyphony::Pipe
   #
   # @param len [Integer, nil] maximum bytes to read
   # @param buf [String, nil] buffer to read into
-  # @param buf_pos [Integer] buffer position to read into
+  # @param buffer_pos [Integer] buffer position to read into
   # @return [String] read data
-  def read(len = nil, buf = nil, buffer_pos: 0)
+  def read(len = nil, buf = nil, buffer_pos = 0)
     return Polyphony.backend_read(self, buf, len, true, buffer_pos) if buf
 
     @read_buffer ||= +''
@@ -59,10 +59,10 @@ class Polyphony::Pipe
   #
   # @param len [Integer, nil] maximum bytes to read
   # @param buf [String, nil] buffer to read into
-  # @param buf_pos [Integer] buffer position to read into
+  # @param buffer_pos [Integer] buffer position to read into
   # @param raise_on_eof [boolean] whether to raise an error if EOF is detected
   # @return [String] read data
-  def readpartial(len, buf = +'', buffer_pos: 0, raise_on_eof: true)
+  def readpartial(len, buf = +'', buffer_pos = 0, raise_on_eof = true)
     result = Polyphony.backend_read(self, buf, len, false, buffer_pos)
     raise EOFError if !result && raise_on_eof
 
@@ -104,7 +104,7 @@ class Polyphony::Pipe
       idx = @read_buffer.index(sep)
       return @read_buffer.slice!(0, idx + sep_size) if idx
 
-      result = readpartial(8192, @read_buffer, buffer_pos: -1)
+      result = readpartial(8192, @read_buffer, -1)
       return nil unless result
     end
   rescue EOFError

--- a/lib/polyphony/extensions/socket.rb
+++ b/lib/polyphony/extensions/socket.rb
@@ -59,7 +59,7 @@ class ::Socket < ::BasicSocket
 
   # Reads from the socket. If `maxlen` is given, reads up to `maxlen` bytes from
   # the socket, otherwise reads to `EOF`. If `buf` is given, it is used as the
-  # buffer to read into, otherwise a new string is allocated. If `buf_pos` is
+  # buffer to read into, otherwise a new string is allocated. If `buffer_pos` is
   # given, reads into the given offset (in bytes) in the given buffer. If the
   # given buffer offset is negative, it is calculated from the current end of
   # the buffer (`-1` means the read data will be appended to the end of the
@@ -70,9 +70,9 @@ class ::Socket < ::BasicSocket
   #
   # @param len [Integer, nil] maximum bytes to read from socket
   # @param buf [String, nil] buffer to read into
-  # @param buf_pos [Number] buffer position to read into
+  # @param buffer_pos [Number] buffer position to read into
   # @return [String] buffer used for reading
-  def read(len = nil, buf = nil, buffer_pos: 0)
+  def read(len = nil, buf = nil, buffer_pos = 0)
     return '' if len == 0
     return Polyphony.backend_read(self, buf, len, true, buffer_pos) if buf
 
@@ -148,7 +148,7 @@ class ::Socket < ::BasicSocket
   end
 
   # Reads up to `maxlen` from the socket. If `buf` is given, it is used as the
-  # buffer to read into, otherwise a new string is allocated. If `buf_pos` is
+  # buffer to read into, otherwise a new string is allocated. If `buffer_pos` is
   # given, reads into the given offset (in bytes) in the given buffer. If the
   # given buffer offset is negative, it is calculated from the current end of
   # the buffer (`-1` means the read data will be appended to the end of the
@@ -160,10 +160,10 @@ class ::Socket < ::BasicSocket
   #
   # @param maxlen [Integer, nil] maximum bytes to read from socket
   # @param buf [String, nil] buffer to read into
-  # @param buf_pos [Number] buffer position to read into
+  # @param buffer_pos [Number] buffer position to read into
   # @param raise_on_eof [bool] whether to raise an exception on `EOF`
   # @return [String, nil] buffer used for reading or nil on `EOF`
-  def readpartial(maxlen, buf = +'', buffer_pos: 0, raise_on_eof: true)
+  def readpartial(maxlen, buf = +'', buffer_pos = 0, raise_on_eof = true)
     result = Polyphony.backend_recv(self, buf, maxlen, buffer_pos)
     raise EOFError if !result && raise_on_eof
 
@@ -320,7 +320,7 @@ class ::TCPSocket < ::IPSocket
 
   # Reads from the socket. If `maxlen` is given, reads up to `maxlen` bytes from
   # the socket, otherwise reads to `EOF`. If `buf` is given, it is used as the
-  # buffer to read into, otherwise a new string is allocated. If `buf_pos` is
+  # buffer to read into, otherwise a new string is allocated. If `buffer_pos` is
   # given, reads into the given offset (in bytes) in the given buffer. If the
   # given buffer offset is negative, it is calculated from the current end of
   # the buffer (`-1` means the read data will be appended to the end of the
@@ -331,9 +331,9 @@ class ::TCPSocket < ::IPSocket
   #
   # @param len [Integer, nil] maximum bytes to read from socket
   # @param buf [String, nil] buffer to read into
-  # @param buf_pos [Number] buffer position to read into
+  # @param buffer_pos [Number] buffer position to read into
   # @return [String] buffer used for reading
-  def read(len = nil, buf = nil, buffer_pos: 0)
+  def read(len = nil, buf = nil, buffer_pos = 0)
     return '' if len == 0
     return Polyphony.backend_read(self, buf, len, true, buffer_pos) if buf
 
@@ -391,7 +391,7 @@ class ::TCPSocket < ::IPSocket
   end
 
   # Reads up to `maxlen` from the socket. If `buf` is given, it is used as the
-  # buffer to read into, otherwise a new string is allocated. If `buf_pos` is
+  # buffer to read into, otherwise a new string is allocated. If `buffer_pos` is
   # given, reads into the given offset (in bytes) in the given buffer. If the
   # given buffer offset is negative, it is calculated from the current end of
   # the buffer (`-1` means the read data will be appended to the end of the
@@ -403,10 +403,10 @@ class ::TCPSocket < ::IPSocket
   #
   # @param maxlen [Integer, nil] maximum bytes to read from socket
   # @param buf [String, nil] buffer to read into
-  # @param buf_pos [Number] buffer position to read into
+  # @param buffer_pos [Number] buffer position to read into
   # @param raise_on_eof [bool] whether to raise an exception on `EOF`
   # @return [String, nil] buffer used for reading or nil on `EOF`
-  def readpartial(maxlen, buf = +'', buffer_pos: 0, raise_on_eof: true)
+  def readpartial(maxlen, buf = +'', buffer_pos = 0, raise_on_eof = true)
     result = Polyphony.backend_recv(self, buf, maxlen, buffer_pos)
     raise EOFError if !result && raise_on_eof
 
@@ -526,7 +526,7 @@ class ::UNIXSocket < ::BasicSocket
 
   # Reads from the socket. If `maxlen` is given, reads up to `maxlen` bytes from
   # the socket, otherwise reads to `EOF`. If `buf` is given, it is used as the
-  # buffer to read into, otherwise a new string is allocated. If `buf_pos` is
+  # buffer to read into, otherwise a new string is allocated. If `buffer_pos` is
   # given, reads into the given offset (in bytes) in the given buffer. If the
   # given buffer offset is negative, it is calculated from the current end of
   # the buffer (`-1` means the read data will be appended to the end of the
@@ -537,9 +537,9 @@ class ::UNIXSocket < ::BasicSocket
   #
   # @param len [Integer, nil] maximum bytes to read from socket
   # @param buf [String, nil] buffer to read into
-  # @param buf_pos [Number] buffer position to read into
+  # @param buffer_pos [Number] buffer position to read into
   # @return [String] buffer used for reading
-  def read(len = nil, buf = nil, buffer_pos: 0)
+  def read(len = nil, buf = nil, buffer_pos = 0)
     return '' if len == 0
     return Polyphony.backend_read(self, buf, len, true, buffer_pos) if buf
 
@@ -623,7 +623,7 @@ class ::UNIXSocket < ::BasicSocket
   end
 
   # Reads up to `maxlen` from the socket. If `buf` is given, it is used as the
-  # buffer to read into, otherwise a new string is allocated. If `buf_pos` is
+  # buffer to read into, otherwise a new string is allocated. If `buffer_pos` is
   # given, reads into the given offset (in bytes) in the given buffer. If the
   # given buffer offset is negative, it is calculated from the current end of
   # the buffer (`-1` means the read data will be appended to the end of the
@@ -635,10 +635,10 @@ class ::UNIXSocket < ::BasicSocket
   #
   # @param maxlen [Integer, nil] maximum bytes to read from socket
   # @param buf [String, nil] buffer to read into
-  # @param buf_pos [Number] buffer position to read into
+  # @param buffer_pos [Number] buffer position to read into
   # @param raise_on_eof [bool] whether to raise an exception on `EOF`
   # @return [String, nil] buffer used for reading or nil on `EOF`
-  def readpartial(maxlen, buf = +'', buffer_pos: 0, raise_on_eof: true)
+  def readpartial(maxlen, buf = +'', buffer_pos = 0, raise_on_eof = true)
     result = Polyphony.backend_recv(self, buf, maxlen, buffer_pos)
     raise EOFError if !result && raise_on_eof
 

--- a/test/test_io.rb
+++ b/test/test_io.rb
@@ -89,7 +89,7 @@ class IOTest < MiniTest::Test
 
     buf = +'def'
     o << 'foobar'
-    assert_equal 'deffoobar', i.read(6, buf, buffer_pos: -1)
+    assert_equal 'deffoobar', i.read(6, buf, -1)
     assert_equal 'deffoobar', buf
   end
 

--- a/test/test_socket.rb
+++ b/test/test_socket.rb
@@ -98,7 +98,7 @@ class TCPSocketTest < MiniTest::Test
 
     buf = +'def'
     client << 'foobar'
-    assert_equal 'deffoobar', client.read(6, buf, buffer_pos: -1)
+    assert_equal 'deffoobar', client.read(6, buf, -1)
     assert_equal 'deffoobar', buf
 
     client.close


### PR DESCRIPTION
Revert a6341eb4709f9ca75a7cc53e010a0de96915fe80, which changes the signature from positional to keyword arguments. This breaks h1p and tipi.
Fixed a couple of invalid references to `buf_pos` as well.