### PR TITLE
Fix thread/mutex race conditions

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -81,6 +81,7 @@ Metrics/MethodLength:
   Exclude:
     - lib/polyphony/extensions/io.rb
     - lib/polyphony/extensions/fiber.rb
+    - lib/polyphony/extensions/thread.rb
     - lib/polyphony/adapters/open3.rb
     - test/**/*.rb
     - examples/**/*.rb
@@ -95,6 +96,7 @@ Metrics/ClassLength:
     - lib/polyphony/extensions/io.rb
     - lib/polyphony/extensions/fiber.rb
     - lib/polyphony/extensions/object.rb
+    - lib/polyphony/extensions/thread.rb
     - test/**/*.rb
     - examples/**/*.rb
 

--- a/ext/polyphony/fiber.c
+++ b/ext/polyphony/fiber.c
@@ -3,7 +3,6 @@
 
 ID ID_ivar_auto_watcher;
 ID ID_ivar_mailbox;
-ID ID_ivar_result;
 ID ID_ivar_waiting_fibers;
 
 VALUE SYM_dead;
@@ -239,7 +238,6 @@ void Init_Fiber(void) {
 
   ID_ivar_auto_watcher    = rb_intern("@auto_watcher");
   ID_ivar_mailbox         = rb_intern("@mailbox");
-  ID_ivar_result          = rb_intern("@result");
   ID_ivar_waiting_fibers  = rb_intern("@waiting_fibers");
 
   SYM_spin                = ID2SYM(rb_intern("spin"));

--- a/ext/polyphony/polyphony.c
+++ b/ext/polyphony/polyphony.c
@@ -13,6 +13,7 @@ ID ID_ivar_blocking_mode;
 ID ID_ivar_io;
 ID ID_ivar_multishot_accept_queue;
 ID ID_ivar_parked;
+ID ID_ivar_result;
 ID ID_ivar_runnable;
 ID ID_ivar_running;
 ID ID_ivar_thread;
@@ -474,6 +475,7 @@ void Init_Polyphony(void) {
   ID_ivar_io                      = rb_intern("@io");
   ID_ivar_multishot_accept_queue  = rb_intern("@multishot_accept_queue");
   ID_ivar_parked                  = rb_intern("@parked");
+  ID_ivar_result                  = rb_intern("@result");
   ID_ivar_runnable                = rb_intern("@runnable");
   ID_ivar_running                 = rb_intern("@running");
   ID_ivar_thread                  = rb_intern("@thread");

--- a/ext/polyphony/polyphony.h
+++ b/ext/polyphony/polyphony.h
@@ -48,6 +48,7 @@ extern ID ID_ivar_blocking_mode;
 extern ID ID_ivar_io;
 extern ID ID_ivar_multishot_accept_queue;
 extern ID ID_ivar_parked;
+extern ID ID_ivar_result;
 extern ID ID_ivar_runnable;
 extern ID ID_ivar_running;
 extern ID ID_ivar_thread;
@@ -147,6 +148,9 @@ VALUE Backend_snooze(VALUE self);
 void Thread_schedule_fiber(VALUE thread, VALUE fiber, VALUE value);
 void Thread_schedule_fiber_with_priority(VALUE thread, VALUE fiber, VALUE value);
 VALUE Thread_switch_fiber(VALUE thread);
+
+VALUE Event_signal(int argc, VALUE *argv, VALUE event);
+VALUE Event_await(VALUE event);
 
 VALUE Polyphony_snooze(VALUE self);
 

--- a/lib/polyphony.rb
+++ b/lib/polyphony.rb
@@ -104,9 +104,6 @@ module Polyphony
       threads = Thread.list - [Thread.current]
       return if threads.empty?
 
-      trace '*' * 40
-      trace threads_left: threads
-
       threads.each(&:kill)
       threads.each(&:join)
     end
@@ -123,10 +120,10 @@ module Polyphony
       # processes,) we use a separate mechanism to terminate fibers in forked
       # processes (see Polyphony.fork).
       at_exit do
-        next unless @original_pid == ::Process.pid
-
-        terminate_threads
-        Fiber.current.shutdown_all_children
+        if @original_pid == ::Process.pid
+          terminate_threads
+          Fiber.current.shutdown_all_children
+        end
       end
     end
   end

--- a/lib/polyphony/extensions/exception.rb
+++ b/lib/polyphony/extensions/exception.rb
@@ -6,6 +6,21 @@ class ::Exception
     # Set to true to disable sanitizing the backtrace (to remove frames occuring
     # in the Polyphony code itself.)
     attr_accessor :__disable_sanitized_backtrace__
+
+    # Creates an exception instance from the given error according to its type.
+    #
+    # @param error [nil, String, Class, Exception] error
+    # @param message [nil, String] error message
+    # @return [Exception] exception instance
+    def instantiate(error = nil, message = nil)
+      case error
+      when String then    RuntimeError.new(error)
+      when Array then     error[0].new(error[1])
+      when Class then     error.new(message)
+      when Exception then error
+      else                RuntimeError.new
+      end
+    end
   end
 
   # Set to the fiber in which the exception was *originally* raised (in case the

--- a/lib/polyphony/extensions/fiber.rb
+++ b/lib/polyphony/extensions/fiber.rb
@@ -167,7 +167,7 @@ class ::Fiber
   #   @param any [Exception] exception to raise
   #   @return [Fiber] self
   def raise(*args)
-    error = error_from_raise_args(args)
+    error = Exception.instantiate(*args)
     schedule(error)
     self
   end
@@ -658,16 +658,6 @@ class ::Fiber
   end
 
   private
-
-  # @!visibility private
-  def error_from_raise_args(args)
-    case (arg = args.shift)
-    when String then RuntimeError.new(arg)
-    when Class  then arg.new(args.shift)
-    when Exception then arg
-    else RuntimeError.new
-    end
-  end
 
   # @!visibility private
   def supervise_opts_to_block(opts)

--- a/lib/polyphony/extensions/object.rb
+++ b/lib/polyphony/extensions/object.rb
@@ -240,25 +240,13 @@ class ::Object
     fiber = Fiber.current
     canceller = spin do
       Polyphony.backend_sleep(interval)
-      exception = cancel_exception(exception)
+      exception = Exception.instantiate(exception)
       exception.raising_fiber = Fiber.current
       fiber.cancel(exception)
     end
     block.call(canceller)
   ensure
     canceller.stop
-  end
-
-  # Converts the given exception spec to an exception instance.
-  #
-  # @param exception [Exception, Class, Array<class, message>] exception spec
-  # @return [Exception] exception instance
-  def cancel_exception(exception)
-    case exception
-    when Class then exception.new
-    when Array then exception[0].new(exception[1])
-    else RuntimeError.new(exception)
-    end
   end
 
   # Helper method for performing `#spin_loop` without throttling. Spins up a

--- a/lib/polyphony/extensions/thread.rb
+++ b/lib/polyphony/extensions/thread.rb
@@ -52,13 +52,9 @@ class ::Thread
   #
   # @param error [Exception, Class, nil] exception spec
   def raise(error = nil)
-    Thread.pass until @main_fiber
-    error = RuntimeError.new if error.nil?
-    error = RuntimeError.new(error) if error.is_a?(String)
-    error = error.new if error.is_a?(Class)
-
     sleep 0.0001 until @ready
 
+    error = Exception.instantiate(error)
     if Thread.current == self
       Kernel.raise(error)
     else

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -17,6 +17,14 @@ require 'minitest/autorun'
 IS_LINUX = RUBY_PLATFORM =~ /linux/
 
 module ::Kernel
+  def debug(**h)
+    k, v = h.first
+    h.delete(k)
+
+    rest = h.inject(+'') { |s, (k, v)| s << "  #{k}: #{v.inspect}\n" }
+    STDOUT.orig_write("#{k}=>#{v} #{caller[0]}\n#{rest}")
+  end
+
   def trace(*args)
     STDOUT.orig_write(format_trace(args))
   end
@@ -42,9 +50,10 @@ class MiniTest::Test
   def setup
     # trace "* setup #{self.name}"
     @__stamp = Time.now
-    Fiber.current.setup_main_fiber
     Thread.current.backend.finalize
     Thread.current.backend = Polyphony::Backend.new
+    Fiber.current.setup_main_fiber
+    Fiber.current.instance_variable_set(:@auto_watcher, nil)
     sleep 0.0001
   end
 

--- a/test/test_backend.rb
+++ b/test/test_backend.rb
@@ -13,6 +13,7 @@ class BackendTest < MiniTest::Test
   def teardown
     @backend.finalize
     Thread.current.backend = @prev_backend
+    super
   end
 
   def test_sleep
@@ -443,6 +444,7 @@ class BackendChainTest < MiniTest::Test
   def teardown
     @backend.finalize
     Thread.current.backend = @prev_backend
+    super
   end
 
   def test_simple_write_chain

--- a/test/test_event.rb
+++ b/test/test_event.rb
@@ -26,11 +26,11 @@ class EventTest < MiniTest::Test
     count = 0
     a = Polyphony::Event.new
 
-    coproc = spin {
+    f = spin {
       loop {
         a.await
         count += 1
-        spin { coproc.stop }
+        spin { f.stop }
       }
     }
     snooze
@@ -40,7 +40,7 @@ class EventTest < MiniTest::Test
       3.times { a.signal }
     end
 
-    coproc.await
+    f.await
     assert_equal 1, count
   ensure
     t&.kill
@@ -56,5 +56,12 @@ class EventTest < MiniTest::Test
     assert_raises(RuntimeError) do
       f.await
     end
+  end
+
+  def test_event_signal_before_await
+    e = Polyphony::Event.new
+    e.signal(:foo)
+
+    assert_equal :foo, e.await
   end
 end

--- a/test/test_fiber.rb
+++ b/test/test_fiber.rb
@@ -1157,9 +1157,11 @@ class FiberControlTest < MiniTest::Test
   end
 
   def test_select_with_interruption
-    f1 = spin { sleep 0.01; :foo }
+    f1 = spin { sleep 0.1; :foo }
     f2 = spin { sleep 1; :bar }
-    spin { snooze; f2.interrupt(:baz) }
+    snooze
+    f2.interrupt(:baz)
+
     result = Fiber.select(f1, f2)
     assert_equal [f2, :baz], result
   end

--- a/test/test_global_api.rb
+++ b/test/test_global_api.rb
@@ -144,24 +144,24 @@ class MoveOnAfterTest < MiniTest::Test
     skip unless IS_LINUX
 
     t0 = monotonic_clock
-    o = move_on_after(0.01, with_value: 1) do
-      move_on_after(0.03, with_value: 2) do
+    o = move_on_after(0.1, with_value: 1) do
+      move_on_after(0.3, with_value: 2) do
         sleep 1
       end
     end
     t1 = monotonic_clock
     assert_equal 1, o
-    assert_in_range 0.008..0.040, t1 - t0 if IS_LINUX
+    assert_in_range 0.08..0.40, t1 - t0 if IS_LINUX
 
     t0 = monotonic_clock
-    o = move_on_after(0.05, with_value: 1) do
-      move_on_after(0.01, with_value: 2) do
+    o = move_on_after(0.5, with_value: 1) do
+      move_on_after(0.1, with_value: 2) do
         sleep 1
       end
     end
     t1 = monotonic_clock
     assert_equal 2, o
-    assert_in_range 0.008..0.035, t1 - t0 if IS_LINUX
+    assert_in_range 0.08..0.35, t1 - t0 if IS_LINUX
   end
 end
 
@@ -256,7 +256,7 @@ class CancelAfterTest < MiniTest::Test
       end
     end
     t1 = monotonic_clock
-    assert_in_range 0.01..0.2, t1 - t0 if IS_LINUX
+    assert_in_range 0.01..0.3, t1 - t0 if IS_LINUX
   end
 end
 

--- a/test/test_thread.rb
+++ b/test/test_thread.rb
@@ -60,7 +60,7 @@ class ThreadTest < MiniTest::Test
   def test_thread_await_alias_method
     buffer = []
     spin { (1..3).each { |i| snooze; buffer << i } }
-    t = Thread.new { sleep 0.01; buffer << 4; :foo }
+    t = Thread.new { sleep 0.1; buffer << 4; :foo }
     r = t.await
     t = nil
 

--- a/test/test_timer.rb
+++ b/test/test_timer.rb
@@ -4,11 +4,13 @@ require_relative 'helper'
 
 class TimerMoveOnAfterTest < MiniTest::Test
   def setup
+    super
     @timer = Polyphony::Timer.new(resolution: 0.01)
   end
 
   def teardown
     @timer.stop
+    super
   end
 
   def test_timer_move_on_after
@@ -56,11 +58,13 @@ end
 
 class TimerCancelAfterTest < MiniTest::Test
   def setup
+    super
     @timer = Polyphony::Timer.new(resolution: 0.01)
   end
 
   def teardown
     @timer.stop
+    super
   end
 
   def test_timer_cancel_after
@@ -134,12 +138,14 @@ end
 
 class TimerMiscTest < MiniTest::Test
   def setup
+    super
     @timer = Polyphony::Timer.new(resolution: 0.001)
     sleep 0
   end
 
   def teardown
     @timer.stop
+    super
   end
 
   def test_timer_after

--- a/test/test_trace.rb
+++ b/test/test_trace.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+__END__
+
 require_relative 'helper'
 require 'polyphony/core/debug'
 


### PR DESCRIPTION
This PR fixes numerous race conditions related to thread termination and use of mutexes.

- Fix possible Event race condition
- Fix race condition in Thread#join
- Refactor exception instantiation
- Skip trace test (tracing will undergo rewrite)
- Reset main fiber autowatcher before each test
- Fix test setup, minor fixes
