### PR TITLE
IO#each_line: return enumerator when no block is given

### DIFF
--- a/lib/polyphony/extensions/io.rb
+++ b/lib/polyphony/extensions/io.rb
@@ -306,6 +306,8 @@ class ::IO
 
   # @!visibility private
   def each_line(sep = $/, limit = nil, chomp: false)
+    return to_enum(:each_line, sep, limit, chomp: chomp) unless block_given?
+
     if sep.is_a?(Integer)
       limit = sep
       sep = $/

--- a/test/test_io.rb
+++ b/test/test_io.rb
@@ -197,6 +197,33 @@ class IOTest < MiniTest::Test
     assert_equal [102, 103], buf
   end
 
+  def test_each_line_with_block
+    file = Tempfile.new
+    file << "foo\nbar\nbaz\n"
+    file.close
+
+    strings = ["foo\n", "bar\n", "baz\n"]
+
+    i = 0
+    File.open(file, 'r').each_line do |line|
+      assert_equal line, strings[i]
+
+      i += 1
+    end
+  end
+
+  def test_each_line_iterator
+    file = Tempfile.new
+    file << "foo\nbar\nbaz\n"
+    file.close
+
+    it = File.open(file, 'r').each_line
+
+    assert_equal it.next, "foo\n"
+    assert_equal it.next, "bar\n"
+    assert_equal it.next, "baz\n"
+  end
+
   # see https://github.com/digital-fabric/polyphony/issues/30
   def test_reopened_tempfile
     file = Tempfile.new


### PR DESCRIPTION
Keep the behaviour of `IO#each_line` consistent with Ruby's implementation: return an `Enumerator` when no block is given.

```ruby
# Before
File.open("myfile.txt", "r").each_line
/usr/local/bundle/gems/polyphony-1.6/lib/polyphony/extensions/io.rb:322:in `each_line': no block given (yield) (LocalJumpError)

# After
File.open("myfile.txt", "r").each_line
 => #<Enumerator: ...>
```