### PR TITLE
fix code order issue in overview.md chat example

### DIFF
--- a/docs/overview.md
+++ b/docs/overview.md
@@ -365,8 +365,8 @@ def chat_user_handler(user_name, connection)
   while command = connection.gets
     case command
     when /^connect (.+)/
-      room&.send [:subscribe, message_subscriber]
       room = CHAT_ROOMS[$1]
+      room&.send [:subscribe, message_subscriber]
     when "disconnect"
       room&.send [:unsubscribe, message_subscriber]
       room = nil


### PR DESCRIPTION
For a minute this threw me off and I tried to figure out what polyphony-specific concept I was misunderstanding, but I've come to the conclusion that these lines are just ordered backwards?