### PR TITLE
Fix issues with debug gem

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
     - name: Setup machine
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Setup Ruby
       uses: ruby/setup-ruby@v1
       with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        ruby: ['3.1', '3.2', 'head']
+        ruby: ['3.1', '3.2', '3.3', 'head']
 
     name: >-
       ${{matrix.os}}, ${{matrix.ruby}}

--- a/.github/workflows/test_io_uring.yml
+++ b/.github/workflows/test_io_uring.yml
@@ -8,7 +8,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        ruby: ['3.1', '3.2', 'head']
+        ruby: ['3.1', '3.2', '3.3', 'head']
 
     name: >-
       ${{matrix.os}}, ${{matrix.ruby}}

--- a/.github/workflows/test_io_uring.yml
+++ b/.github/workflows/test_io_uring.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ${{matrix.os}}
     steps:
     - name: Checkout repository and submodules
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         submodules: recursive
     - name: Setup Ruby

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 3.2
+  TargetRubyVersion: 3.3
   RubyInterpreters:
     - ruby
   Exclude:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,6 +9,7 @@ AllCops:
     - 'Gemfile*'
     - 'ext/**/*.rb'
     - lib/polyphony/adapters/irb.rb
+  NewCops: enable
 
 Style/LambdaCall:
   Enabled: false

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 ## What is Polyphony?
 
 Polyphony is a library for building concurrent applications in Ruby. Polyphony
-harnesses the power of [Ruby fibers](https://rubyapi.org/3.2/o/fiber) to provide
+harnesses the power of [Ruby fibers](https://rubyapi.org/3.3/o/fiber) to provide
 a cooperative, sequential coroutine-based concurrency model. Under the hood,
 Polyphony uses [io_uring](https://unixism.net/loti/what_is_io_uring.html) or
 [libev](https://github.com/enki/libev) to maximize I/O performance.

--- a/docs/advanced-io.md
+++ b/docs/advanced-io.md
@@ -119,7 +119,7 @@ minimizing memory use and GC pressure.
 ## Compressing and decompressing in-flight data
 
 You might be familiar with Ruby's [zlib](https://github.com/ruby/zlib) gem (docs
-[here](https://rubyapi.org/3.2/o/zlib)), which can be used to compress and
+[here](https://rubyapi.org/3.3/o/zlib)), which can be used to compress and
 uncompress data using the popular gzip format. Imagine we want to implement an
 HTTP server that can serve files compressed using gzip:
 

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -25,7 +25,7 @@
 ## What is Polyphony?
 
 Polyphony is a library for building concurrent applications in Ruby. Polyphony
-harnesses the power of [Ruby fibers](https://rubyapi.org/3.2/o/fiber) to provide
+harnesses the power of [Ruby fibers](https://rubyapi.org/3.3/o/fiber) to provide
 a cooperative, sequential coroutine-based concurrency model. Under the hood,
 Polyphony uses [io_uring](https://unixism.net/loti/what_is_io_uring.html) or
 [libev](https://github.com/enki/libev) to maximize I/O performance.

--- a/lib/polyphony/extensions/io.rb
+++ b/lib/polyphony/extensions/io.rb
@@ -60,9 +60,9 @@ class ::IO
     end
 
     alias_method :orig_readlines, :readlines
-    def readlines(name, sep = $/, limit = nil, getline_args = EMPTY_HASH)
+    def readlines(name, sep = $/, limit = nil, getline_args = EMPTY_HASH, chomp: false)
       File.open(name, 'r') do |f|
-        f.readlines(sep, **getline_args)
+        f.readlines(sep, chomp: chomp, **getline_args)
       end
     end
 

--- a/polyphony.gemspec
+++ b/polyphony.gemspec
@@ -20,15 +20,15 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
   s.required_ruby_version = '>= 3.1'
 
-  s.add_development_dependency  'rake-compiler',        '1.2.1'
-  s.add_development_dependency  'minitest',             '5.17.0'
+  s.add_development_dependency  'rake-compiler',        '1.2.7'
+  s.add_development_dependency  'minitest',             '5.22.3'
   s.add_development_dependency  'simplecov',            '0.22.0'
-  s.add_development_dependency  'rubocop',              '1.45.1'
+  s.add_development_dependency  'rubocop',              '1.62.1'
   s.add_development_dependency  'pry',                  '0.14.2'
 
-  s.add_development_dependency  'msgpack',              '1.6.0'
+  s.add_development_dependency  'msgpack',              '1.7.2'
   s.add_development_dependency  'httparty',             '0.21.0'
-  s.add_development_dependency  'localhost',            '1.1.10'
-  s.add_development_dependency  'debug',                '1.8.0'
-  s.add_development_dependency  'benchmark-ips',        '2.10.0'
+  s.add_development_dependency  'localhost',            '1.2.0'
+  s.add_development_dependency  'debug',                '1.9.1'
+  s.add_development_dependency  'benchmark-ips',        '2.13.0'
 end

--- a/polyphony.gemspec
+++ b/polyphony.gemspec
@@ -31,4 +31,10 @@ Gem::Specification.new do |s|
   s.add_development_dependency  'localhost',            '1.2.0'
   s.add_development_dependency  'debug',                '1.9.1'
   s.add_development_dependency  'benchmark-ips',        '2.13.0'
+
+  # FIXME: remove gems when all other dependencies have bundled them (not part of stdlib since Ruby 3.4)
+  s.add_development_dependency  'base64',               '0.2.0'
+  s.add_development_dependency  'bigdecimal',           '3.1.7'
+  s.add_development_dependency  'csv',                  '3.3.0'
+  s.add_development_dependency  'mutex_m',              '0.2.0'
 end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -46,6 +46,8 @@ module ::Kernel
   end
 end
 
+module MiniTest; end
+
 class MiniTest::Test
   def setup
     # trace "* setup #{self.name}"

--- a/test/test_io.rb
+++ b/test/test_io.rb
@@ -642,6 +642,12 @@ class IOClassMethodsTest < MiniTest::Test
     assert_equal "end\n", lines[-1]
   end
 
+  def test_readlines_with_chomp
+    lines = IO.readlines(__FILE__, chomp: true)
+    assert_equal "# frozen_string_literal: true", lines[0]
+    assert_equal "end", lines[-1]
+  end
+
   WRITE_DATA = "foo\nbar קוקו"
 
   def test_write_class_method


### PR DESCRIPTION
Fix some issues with the `debug` gem.

- Support `IO#readlines` with [`chomp` argument](https://github.com/ruby/ruby/blob/master/io.c#L4402), as called by debug in [`source_repository.rb`](https://github.com/ruby/debug/blob/v1.9.1/lib/debug/source_repository.rb#L11).