### PR TITLE
Target Ruby 3.4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,10 @@ jobs:
     name: >-
       ${{matrix.os}}, ${{matrix.ruby}}
 
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{matrix.os}}-${{matrix.ruby}}-libev
+      cancel-in-progress: true
+
     runs-on: ${{matrix.os}}
 
     env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
     - name: Setup machine
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Setup Ruby
       uses: ruby/setup-ruby@v1
       with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        ruby: ['3.1', '3.2', 'head']
+        ruby: ['3.1', '3.2', '3.3', 'head']
 
     name: >-
       ${{matrix.os}}, ${{matrix.ruby}}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        ruby: ['3.1', '3.2', '3.3', '3.4', 'head']
+        ruby: ['3.2', '3.3', '3.4', 'head']
 
     name: >-
       ${{matrix.os}}, ${{matrix.ruby}}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        ruby: ['3.1', '3.2', '3.3', 'head']
+        ruby: ['3.1', '3.2', '3.3', '3.4', 'head']
 
     name: >-
       ${{matrix.os}}, ${{matrix.ruby}}

--- a/.github/workflows/test_io_uring.yml
+++ b/.github/workflows/test_io_uring.yml
@@ -13,7 +13,12 @@ jobs:
     name: >-
       ${{matrix.os}}, ${{matrix.ruby}}
 
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{matrix.os}}-${{matrix.ruby}}-io_uring
+      cancel-in-progress: true
+
     runs-on: ${{matrix.os}}
+
     steps:
     - name: Checkout repository and submodules
       uses: actions/checkout@v4

--- a/.github/workflows/test_io_uring.yml
+++ b/.github/workflows/test_io_uring.yml
@@ -8,7 +8,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        ruby: ['3.1', '3.2', 'head']
+        ruby: ['3.1', '3.2', '3.3', 'head']
 
     name: >-
       ${{matrix.os}}, ${{matrix.ruby}}

--- a/.github/workflows/test_io_uring.yml
+++ b/.github/workflows/test_io_uring.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ${{matrix.os}}
     steps:
     - name: Checkout repository and submodules
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         submodules: recursive
     - name: Setup Ruby

--- a/.github/workflows/test_io_uring.yml
+++ b/.github/workflows/test_io_uring.yml
@@ -8,7 +8,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        ruby: ['3.1', '3.2', '3.3', '3.4', 'head']
+        ruby: ['3.2', '3.3', '3.4', 'head']
 
     name: >-
       ${{matrix.os}}, ${{matrix.ruby}}

--- a/.github/workflows/test_io_uring.yml
+++ b/.github/workflows/test_io_uring.yml
@@ -8,7 +8,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        ruby: ['3.1', '3.2', '3.3', 'head']
+        ruby: ['3.1', '3.2', '3.3', '3.4', 'head']
 
     name: >-
       ${{matrix.os}}, ${{matrix.ruby}}

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 3.2
+  TargetRubyVersion: 3.3
   RubyInterpreters:
     - ruby
   Exclude:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,6 +9,7 @@ AllCops:
     - 'Gemfile*'
     - 'ext/**/*.rb'
     - lib/polyphony/adapters/irb.rb
+  NewCops: enable
 
 Style/LambdaCall:
   Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 3.3
+  TargetRubyVersion: 3.4
   RubyInterpreters:
     - ruby
   Exclude:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Add support for Ruby 3.3 and 3.4
 - Remove support for Ruby 3.1
+- Forward keyword arguments in `Polyphony::ResourcePool`
 
 ## 1.6 2023-08-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- Add support for Ruby 3.3
+
 ## 1.6 2023-08-05
 
 - Refactor exception instantiation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 - Add support for Ruby 3.3 and 3.4
+- Remove support for Ruby 3.1
 
 ## 1.6 2023-08-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Unreleased
 
-- Add support for Ruby 3.3
+- Add support for Ruby 3.3 and 3.4
 
 ## 1.6 2023-08-05
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 ## What is Polyphony?
 
 Polyphony is a library for building concurrent applications in Ruby. Polyphony
-harnesses the power of [Ruby fibers](https://rubyapi.org/3.2/o/fiber) to provide
+harnesses the power of [Ruby fibers](https://rubyapi.org/3.3/o/fiber) to provide
 a cooperative, sequential coroutine-based concurrency model. Under the hood,
 Polyphony uses [io_uring](https://unixism.net/loti/what_is_io_uring.html) or
 [libev](https://github.com/enki/libev) to maximize I/O performance.

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 ## What is Polyphony?
 
 Polyphony is a library for building concurrent applications in Ruby. Polyphony
-harnesses the power of [Ruby fibers](https://rubyapi.org/3.3/o/fiber) to provide
+harnesses the power of [Ruby fibers](https://rubyapi.org/3.4/o/fiber) to provide
 a cooperative, sequential coroutine-based concurrency model. Under the hood,
 Polyphony uses [io_uring](https://unixism.net/loti/what_is_io_uring.html) or
 [libev](https://github.com/enki/libev) to maximize I/O performance.

--- a/docs/advanced-io.md
+++ b/docs/advanced-io.md
@@ -119,7 +119,7 @@ minimizing memory use and GC pressure.
 ## Compressing and decompressing in-flight data
 
 You might be familiar with Ruby's [zlib](https://github.com/ruby/zlib) gem (docs
-[here](https://rubyapi.org/3.2/o/zlib)), which can be used to compress and
+[here](https://rubyapi.org/3.3/o/zlib)), which can be used to compress and
 uncompress data using the popular gzip format. Imagine we want to implement an
 HTTP server that can serve files compressed using gzip:
 

--- a/docs/advanced-io.md
+++ b/docs/advanced-io.md
@@ -119,7 +119,7 @@ minimizing memory use and GC pressure.
 ## Compressing and decompressing in-flight data
 
 You might be familiar with Ruby's [zlib](https://github.com/ruby/zlib) gem (docs
-[here](https://rubyapi.org/3.3/o/zlib)), which can be used to compress and
+[here](https://rubyapi.org/3.4/o/zlib)), which can be used to compress and
 uncompress data using the popular gzip format. Imagine we want to implement an
 HTTP server that can serve files compressed using gzip:
 

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -25,7 +25,7 @@
 ## What is Polyphony?
 
 Polyphony is a library for building concurrent applications in Ruby. Polyphony
-harnesses the power of [Ruby fibers](https://rubyapi.org/3.2/o/fiber) to provide
+harnesses the power of [Ruby fibers](https://rubyapi.org/3.3/o/fiber) to provide
 a cooperative, sequential coroutine-based concurrency model. Under the hood,
 Polyphony uses [io_uring](https://unixism.net/loti/what_is_io_uring.html) or
 [libev](https://github.com/enki/libev) to maximize I/O performance.

--- a/lib/polyphony/core/resource_pool.rb
+++ b/lib/polyphony/core/resource_pool.rb
@@ -56,9 +56,10 @@ module Polyphony
     #
     # @param sym [Symbol] method name
     # @param args [Array<any>] method arguments
+    # @param kwargs [Hash] keyword arguments
     # @return [any] result of method call
-    def method_missing(sym, *args, &block)
-      acquire { |r| r.send(sym, *args, &block) }
+    def method_missing(sym, *args, **kwargs, &block)
+      acquire { |r| r.send(sym, *args, **kwargs, &block) }
     end
 
     # @!visibility private

--- a/lib/polyphony/extensions/io.rb
+++ b/lib/polyphony/extensions/io.rb
@@ -28,19 +28,16 @@ class ::IO
     end
 
     # @!visibility private
-    EMPTY_HASH = {}.freeze
-
-    # @!visibility private
     alias_method :orig_foreach, :foreach
 
     # @!visibility private
-    def foreach(name, sep = $/, limit = nil, getline_args = EMPTY_HASH, &block)
+    def foreach(name, sep = $/, limit = nil, **kwargs, &block)
       if sep.is_a?(Integer)
         sep = $/
         limit = sep
       end
       File.open(name, 'r') do |f|
-        f.each_line(sep, limit, chomp: getline_args[:chomp], &block)
+        f.each_line(sep, limit, chomp: kwargs[:chomp], &block)
       end
     end
 
@@ -48,21 +45,21 @@ class ::IO
     alias_method :orig_read, :read
 
     # @!visibility private
-    def read(name, length = nil, offset = nil, opt = EMPTY_HASH)
+    def read(name, length = nil, offset = nil, **kwargs)
       if length.is_a?(Hash)
-        opt = length
+        kwargs = length
         length = nil
       end
-      File.open(name, opt[:mode] || 'r') do |f|
+      File.open(name, kwargs[:mode] || 'r') do |f|
         f.seek(offset) if offset
         length ? f.read(length) : f.read
       end
     end
 
     alias_method :orig_readlines, :readlines
-    def readlines(name, sep = $/, limit = nil, getline_args = EMPTY_HASH)
+    def readlines(name, sep = $/, limit = nil, **kwargs)
       File.open(name, 'r') do |f|
-        f.readlines(sep, **getline_args)
+        f.readlines(sep, **kwargs)
       end
     end
 
@@ -70,8 +67,8 @@ class ::IO
     alias_method :orig_write, :write
 
     # @!visibility private
-    def write(name, string, offset = nil, opt = EMPTY_HASH)
-      File.open(name, opt[:mode] || 'w') do |f|
+    def write(name, string, offset = nil, **kwargs)
+      File.open(name, kwargs[:mode] || 'w') do |f|
         f.seek(offset) if offset
         f.write(string)
       end

--- a/polyphony.gemspec
+++ b/polyphony.gemspec
@@ -31,4 +31,10 @@ Gem::Specification.new do |s|
   s.add_development_dependency  'localhost',            '1.5.0'
   s.add_development_dependency  'debug',                '1.10.0'
   s.add_development_dependency  'benchmark-ips',        '2.14.0'
+
+  # FIXME: remove gems when all other dependencies have bundled them (not part of stdlib since Ruby 3.4)
+  s.add_development_dependency  'base64',               '0.2.0'
+  s.add_development_dependency  'bigdecimal',           '3.1.9'
+  s.add_development_dependency  'csv',                  '3.3.4'
+  s.add_development_dependency  'mutex_m',              '0.3.0'
 end

--- a/polyphony.gemspec
+++ b/polyphony.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.extra_rdoc_files = ["README.md"]
   s.extensions = ["ext/polyphony/extconf.rb"]
   s.require_paths = ["lib"]
-  s.required_ruby_version = '>= 3.1'
+  s.required_ruby_version = '>= 3.2'
 
   s.add_development_dependency  'rake-compiler',        '1.2.1'
   s.add_development_dependency  'minitest',             '5.17.0'

--- a/polyphony.gemspec
+++ b/polyphony.gemspec
@@ -20,15 +20,15 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
   s.required_ruby_version = '>= 3.2'
 
-  s.add_development_dependency  'rake-compiler',        '1.2.1'
-  s.add_development_dependency  'minitest',             '5.17.0'
+  s.add_development_dependency  'rake-compiler',        '1.3.0'
+  s.add_development_dependency  'minitest',             '5.25.5'
   s.add_development_dependency  'simplecov',            '0.22.0'
-  s.add_development_dependency  'rubocop',              '1.45.1'
-  s.add_development_dependency  'pry',                  '0.14.2'
+  s.add_development_dependency  'rubocop',              '1.62.1'
+  s.add_development_dependency  'pry',                  '0.15.2'
 
-  s.add_development_dependency  'msgpack',              '1.6.0'
-  s.add_development_dependency  'httparty',             '0.21.0'
-  s.add_development_dependency  'localhost',            '1.1.10'
-  s.add_development_dependency  'debug',                '1.8.0'
-  s.add_development_dependency  'benchmark-ips',        '2.10.0'
+  s.add_development_dependency  'msgpack',              '1.8.0'
+  s.add_development_dependency  'httparty',             '0.23.1'
+  s.add_development_dependency  'localhost',            '1.5.0'
+  s.add_development_dependency  'debug',                '1.10.0'
+  s.add_development_dependency  'benchmark-ips',        '2.14.0'
 end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -45,6 +45,14 @@ module ::Kernel
   def monotonic_clock
     ::Process.clock_gettime(::Process::CLOCK_MONOTONIC)
   end
+
+  def inspect_method_name_for(klass_name, method_name)
+    if RUBY_VERSION < '3.4.0'
+      "`#{method_name}'"
+    else
+      "'#{klass_name}##{method_name}'"
+    end
+  end
 end
 
 class MiniTest::Test

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -11,6 +11,7 @@ require 'fileutils'
 require_relative './eg'
 
 require 'minitest/autorun'
+require 'minitest/unit'
 
 ::Exception.__disable_sanitized_backtrace__ = true
 

--- a/test/test_fiber.rb
+++ b/test/test_fiber.rb
@@ -619,7 +619,7 @@ class FiberTest < MiniTest::Test
     f = spin(:baz) { :foo }
 
     expected = format(
-      '#<Fiber baz:%s %s:%d:in `test_inspect\' (runnable)>',
+      "#<Fiber baz:%s %s:%d:in #{inspect_method_name_for(self.class.name, __method__.to_s)} (runnable)>",
       f.object_id,
       __FILE__,
       spin_line_no
@@ -627,8 +627,9 @@ class FiberTest < MiniTest::Test
     assert_equal expected, f.inspect
 
     f.await
+
     expected = format(
-      '#<Fiber baz:%s %s:%d:in `test_inspect\' (dead)>',
+      "#<Fiber baz:%s %s:%d:in #{inspect_method_name_for(self.class.name, __method__.to_s)} (dead)>",
       f.object_id,
       __FILE__,
       spin_line_no

--- a/test/test_thread.rb
+++ b/test/test_thread.rb
@@ -133,7 +133,7 @@ class ThreadTest < MiniTest::Test
     Thread.backend.trace_proc = proc {|*r| records << r }
     suspend
     assert_equal [
-      [:block, Fiber.current, ["#{__FILE__}:#{__LINE__ - 2}:in `test_that_suspend_returns_immediately_if_no_watchers'"] + caller]
+      [:block, Fiber.current, ["#{__FILE__}:#{__LINE__ - 2}:in #{inspect_method_name_for(self.class.name, __method__.to_s)}"] + caller]
     ], records
   ensure
     Thread.backend.trace_proc = nil


### PR DESCRIPTION
Add Ruby 3.3 and 3.4 to the CI version matrix.
Remove Ruby 3.1 (EoL) from the CI version matrix.

Fix test suite for Ruby main
- Temporarily add [gems](https://github.com/digital-fabric/polyphony/actions/runs/7471212227/job/20402710013) to development dependencies (removed from stdlib in Ruby 3.4)
- [Backtrace display changed](https://bugs.ruby-lang.org/issues/19117) if the class has a permanent name

Other fixes
- Add keyword arguments to the `method_missing` in `Polyphony::ResourcePool`. Resolves instances of `redis.set("key", "value", ex:5)`
- Cancel Github Actions runs in progress when pushing a new commit